### PR TITLE
Fix addition of SSL redirect middleware in secure API defaults

### DIFF
--- a/src/ring/middleware/defaults.clj
+++ b/src/ring/middleware/defaults.clj
@@ -28,7 +28,7 @@
 (def secure-api-defaults
   "A default configuration for a HTTP API that's accessed securely over HTTPS."
   (-> api-defaults
-      (assoc-in [:security :redirect-ssl] true)
+      (assoc-in [:security :ssl-redirect] true)
       (assoc-in [:security :hsts] true)))
 
 (def site-defaults


### PR DESCRIPTION
Hey James,

I'm in the process of replacing listora/ring-ssl in one of our applications with ring-defaults and noticed redirects stopped working.

I'm not sure which way round you'd want to fix this, but in one place `:redirect-ssl` is used, and in another `:ssl-redirect`. I went with `:redirect-ssl` because it's closer to how I'd say it, but I don't feel too strongly either way.

I haven't tested this, and will workaround by `assoc`'ing in the expected key.
