### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The following configuration keys are supported:
     Any redirects to relative URLs will be turned into redirects to
     absolute URLs, to better conform to the HTTP spec.
 
-  - `:content-type` -
+  - `:content-types` -
     Adds the standard Ring [content-type][3] middleware.
 
   - `:default-charset` -


### PR DESCRIPTION
There was a discrepancy between the code and the README. The README said ```:content-type``` while it is actually ```:content-types``` in the code.