### PR TITLE
updated to a compatible version of ring-core

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [ring/ring-core "1.6.0"]
+                 [ring/ring-core "1.6.2"]
                  [ring/ring-ssl "0.3.0"]
                  [ring/ring-headers "0.3.0"]
                  [ring/ring-anti-forgery "1.1.0"]


### PR DESCRIPTION
Using ring-core `1.6.0` fails an assert with the following error:

```
java.lang.AssertionError: Assert failed: (every? valid-attr? attrs)
	at ring.middleware.cookies$write_attr_map.invokeStatic(cookies.clj:73) ~[na:na]
	at ring.middleware.cookies$write_attr_map.invoke(cookies.clj:73) ~[na:na]
	at ring.middleware.cookies$write_cookies$iter__34614__34618$fn__34619.invoke(cookies.clj:92) ~[na:na]
```