### PR TITLE
Update ring-core to 1.8.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [ring/ring-core "1.6.3"]
+                 [ring/ring-core "1.8.0"]
                  [ring/ring-ssl "0.3.0"]
                  [ring/ring-headers "0.3.0"]
                  [ring/ring-anti-forgery "1.3.0"]


### PR DESCRIPTION
Update ring-core from 1.6.3 to 1.8.0

We need to update ring-core because of using "SameSite:None" attribute.
Chrome will change default SameSite value from lax to no value at 02/03/2020 and not allow users to use cookie without "Samesite:None Secure" attribute at crossing browsers.

https://www.chromestatus.com/feature/5088147346030592