### PR TITLE
Maintenance: dependency bump; Clojure 1.10 testing

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,17 +2,17 @@
   :description "Ring middleware that provides sensible defaults"
   :url "https://github.com/ring-clojure/ring-defaults"
   :license {:name "The MIT License"
-            :url "http://opensource.org/licenses/MIT"}
+            :url  "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [ring/ring-core "1.6.3"]
+                 [ring/ring-core "1.8.1"]
                  [ring/ring-ssl "0.3.0"]
                  [ring/ring-headers "0.3.0"]
                  [ring/ring-anti-forgery "1.3.0"]
                  [javax.servlet/javax.servlet-api "3.1.0"]]
   :aliases {"test-all" ["with-profile" "default:+1.6:+1.7:+1.8:+1.9" "test"]}
   :profiles
-  {:dev {:dependencies [[ring/ring-mock "0.3.2"]]}
-   :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
-   :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
-   :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-   :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}})
+  {:dev  {:dependencies [[ring/ring-mock "0.4.0"]]}
+   :1.6  {:dependencies [[org.clojure/clojure "1.6.0"]]}
+   :1.7  {:dependencies [[org.clojure/clojure "1.7.0"]]}
+   :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
+   :1.9  {:dependencies [[org.clojure/clojure "1.9.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -9,10 +9,11 @@
                  [ring/ring-headers "0.3.0"]
                  [ring/ring-anti-forgery "1.3.0"]
                  [javax.servlet/javax.servlet-api "3.1.0"]]
-  :aliases {"test-all" ["with-profile" "default:+1.6:+1.7:+1.8:+1.9" "test"]}
+  :aliases {"test-all" ["with-profile" "default:+1.6:+1.7:+1.8:+1.9:+1.10" "test"]}
   :profiles
   {:dev  {:dependencies [[ring/ring-mock "0.4.0"]]}
    :1.6  {:dependencies [[org.clojure/clojure "1.6.0"]]}
    :1.7  {:dependencies [[org.clojure/clojure "1.7.0"]]}
    :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
-   :1.9  {:dependencies [[org.clojure/clojure "1.9.0"]]}})
+   :1.9  {:dependencies [[org.clojure/clojure "1.9.0"]]}
+   :1.10 {:dependencies [[org.clojure/clojure "1.10.1"]]}})


### PR DESCRIPTION
This pull request combines four commits that update `ring-defaults`’s dependencies; add testing against Clojure 1.10.1; substantially improve its `README.md`, mostly in small ways; and release these changes as version 0.3.3.

The code itself is entirely untouched. All testing (as performed by `lein test`) passed after all changes. The commits are defect-free to the best of my determination.

Thanks for your time.