### PR TITLE
Comprehensive edit of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,32 @@
-# Ring-Defaults
+# ring-defaults
 
 [![Build Status](https://travis-ci.org/ring-clojure/ring-defaults.svg?branch=master)](https://travis-ci.org/ring-clojure/ring-defaults)
 
-Knowing what middleware to add to a Ring application, and in what
-order, can be difficult and prone to error.
+Choosing and ordering middleware for a Ring application can be difficult and error-prone.
 
-This library attempts to automate the process, by providing sensible
-and secure default configurations of Ring middleware for both websites
-and HTTP APIs.
+This library attempts to automate the process by providing sensible and secure default configurations of Ring middleware for both websites and HTTP APIs.
 
 ## Installation
 
+### Leiningen
+
 Add the following dependency to your `project.clj`:
 
-    [ring/ring-defaults "0.3.2"]
+```clojure
+[ring/ring-defaults "0.3.2"]
+```
 
-## Basic Usage
+### Clojure Deps
 
-The `wrap-defaults` middleware sets up standard Ring middleware based
-on a supplied configuration:
+Merge the following into your `deps.edn`:
+
+```clojure
+{:deps {ring/ring-defaults {:mvn/version "0.3.2"}}}
+```
+
+## Basic usage
+
+The `wrap-defaults` middleware sets up standard Ring middleware based on a supplied configuration:
 
 ```clojure
 (require '[ring.middleware.defaults :refer :all])
@@ -27,141 +35,108 @@ on a supplied configuration:
   (wrap-defaults handler site-defaults))
 ```
 
-There are four configurations included with the middleware
+There are four included configurations:
 
-- `api-defaults`
-- `site-defaults`
-- `secure-api-defaults`
-- `secure-site-defaults`
+* `api-defaults`
+* `site-defaults`
+* `secure-api-defaults`
+* `secure-site-defaults`
 
-The "api" defaults will add support for urlencoded parameters, but not
-much else.
+The `api` defaults add support for URL-encoded parameters, but not much else.
 
-The "site" defaults add support for parameters, cookies, sessions,
-static resources, file uploads, and a bunch of browser-specific
-security headers.
+The `site` defaults add support for parameters, cookies, sessions, static resources, file uploads, and a bunch of browser-specific security headers.
 
-The "secure" defaults force SSL. Unencrypted HTTP URLs are redirected
-to the equivlant HTTPS URL, and various headers and flags are sent to
-prevent the browser sending sensitive information over insecure
-channels.
+The `secure` defaults force SSL; redirect unencrypted HTTP requests to the equivalent HTTPS URL; send various headers and flags to prevent the browser from sending sensitive information over insecure channels.
 
 ## Proxies
 
-If your app is sitting behind a load balancer or reverse proxy, as is
-often the case in cloud-based deployments, you'll want to set `:proxy`
-to `true`:
-
+Set `:proxy` to `true` if your application sits behind a load balancer or other reverse proxy, as is often the case in cloud-based deployments:
 ```clojure
 (assoc secure-site-defaults :proxy true)
 ```
 
-This is particularly important when your site is secured with SSL, as
-the SSL redirect middleware will get caught in a redirect loop if it
-can't determine the correct URL scheme of the request.
+This is particularly important for sites secured with SSL: the SSL redirection middleware will get caught in a redirect loop if it can’t determine the request’s correct URL scheme.
 
 ## Customizing
 
-The default configurations are just maps of options, and can be
-customized to suit your needs. For example, if you wanted the normal
-site defaults, but without session support, you could use:
-
+The default configurations are just maps of options, and can be customized to suit your needs. For example, if you wanted the normal site defaults, but without session support, you could use:
 ```clojure
 (wrap-defaults handler (assoc site-defaults :session false))
 ```
 
-The following configuration keys are supported:
+Supported configuration keys are:
 
-- `:cookies` - Set to true to parse cookies from the request.
+* `:cookies` – set to `true` to parse cookies from the request.
 
-- `:params` -
-  A map of options that describes how to parse parameters from the
-  request.
+* `:params` – a map of options that describes how to parse parameters from the
+  request:
   
-  - `:keywordize` -
-    Set to true to turn the parameter keys into keywords.
+  * `:keywordize` – set to `true` to turn the parameter keys into keywords.
     
-  - `:multipart` -
-    Set to true to parse urlencoded parameters in the query string and
-    the request body, or supply a map of options to pass to the
-    standard Ring [multipart-params][1] middleware.
+  * `:multipart` – set to `true` to parse URL-encoded parameters, in both the query string and request body; or supply a map of options to pass to [the standard Ring multipart-params middleware][1].
 
-  - `:nested` -
-    Set to true to allow nested parameters via the standard Ring
-    [nested-params][2] middleware
+  * `:nested` – set to `true` to allow nested parameters, via [the standard Ring nested-params middleware][2].
 
-  - `:urlencoded` -
-    Set to true to parse urlencoded parameters in the query string and
-    the request body.
+  * `:urlencoded` – set to `true` to parse URL-encoded parameters, in both the query string and request body.
 
-- `:proxy` -
-  Set to true if the application is running behind a reverse proxy or
-  load balancer.
+* `:proxy` – set to `true` if the application runs behind a reverse proxy or load balancer.
 
-- `:responses` -
-  A map of options to augment the responses from your application.
+* `:responses` – a map of options to augment the application’s responses:
 
-  - `:absolute-redirects` -
-    Any redirects to relative URLs will be turned into redirects to
-    absolute URLs, to better conform to the HTTP spec.
+  * `:absolute-redirects` – set to `true` to replace any relative URLs in redirects with     absolute URLs, to better conform to the HTTP specification.
 
-  - `:content-types` -
-    Adds the standard Ring [content-type][3] middleware.
+  * `:content-types` – set to `true` to add [the standard Ring content-type middleware][3].
 
-  - `:default-charset` -
-    Adds a default charset to any text content-type lacking a charset.
+  * `:default-charset` – set to `true` to add a default `charset` to `Content-Type: text/*` headers that lack a `charset`.
 
-  - `:not-modified-responses` -
-    Adds the standard Ring [not-modified][4] middleware.
+  * `:not-modified-responses` – set to `true` to add [the standard Ring not-modified middleware][4].
 
-- `:security` -
-  Options for security related behaviors and headers.
+* `:security` – a map of options for security-related behaviors and headers:
 
-  - `:anti-forgery` -
-    Set to true to add CSRF protection via the [ring-anti-forgery][5]
-    library.
+  * `:anti-forgery` – set to `true` to add CSRF protection, via [the ring-anti-forgery
+    library][5].
 
-  - `:content-type-options` -
-    Prevents attacks based around media-type confusion. See:
-    [wrap-content-type-options][6].
+  * `:content-type-options` – set to `true` to prevent attacks based around `Content-Type` confusion. See [wrap-content-type-options][6].
 
-  - `:frame-options` -
-    Prevents your site from being placed in frames or iframes. See:
-    [wrap-frame-options][7].
+  * `:frame-options` – set to `true` to prevent the application from being placed in frames or iframes. See [wrap-frame-options][7].
     
-  - `:hsts` -
-    If true, enable HTTP Strict Transport Security. See: [wrap-hsts][8].
+  * `:hsts` – set to `true` to enable HTTP Strict Transport Security. See [wrap-hsts][8].
     
-  - `:ssl-redirect` -
-    If true, redirect all HTTP requests to the equivalent HTTPS URL. A
-    map with an `:ssl-port` option may be set instead, if the HTTPS
-    server is on a non-standard port. See: [wrap-ssl-redirect][9].
+  * `:ssl-redirect` – set to `true` to redirect all HTTP requests to the equivalent HTTPS URL; or set to a map with an `:ssl-port` option for the same functionality where the HTTPS server is on a non-standard port:
+    ```clojure
+    {:ssl-redirect true}
+    {:ssl-redirect {:ssl-port "1234"}}
+    ```
+    
+    See [wrap-ssl-redirect][9].
 
-  - `:xss-protection` -
-    Enable the X-XSS-Protection header that tells supporting browsers
-    to use heuristics to detect XSS attacks. See: [wrap-xss-protection][10].
+  * `:xss-protection` – set to `true` to enable the `X-XSS-Protection` header that tells supporting browsers to use heuristics to detect XSS attacks. See [wrap-xss-protection][10].
 
-- `:session` -
-  A map of options for configuring session handling via the Ring
-  [session][11] middleware.
+* `:session` – a map of options for handling sessions, via [the standard Ring session middleware][11]:
 
-  - `:flash` - If set to true, the Ring [flash][12] middleware is added.
+  * `:flash` – set to `true` to add [the Ring flash middleware][12].
 
-  - `:store` - The Ring session store to use for storing sessions.
+  * `:store` – set to an implementation of [the Ring session middleware’s `SessionStore` protocol][13] to override the default [memory session store][14]:
+    ```clojure
+    {:store ring.middleware.session.cookie/cookie-store}
+    {:store myapplication.session/my-session-store}
+    ```
 
-- `:static`
-  A map of options to configure how to find static content.
+* `:static` – a map of options to configure how to find static content:
 
-  - `:files` -
-    A string or collection of strings containing paths to directories
-    to serve files from. Usually the `:resources` option below is
-    more useful.
+  * `:files` – set to a `String` containing a directory path, or a collection of at least one of the same, to serve files found in the location(s) given:
+    ```clojure
+    {:files "/mnt/static"}
+    {:files #{"/mnt/static" "/mnt/static-supplement"}}
+    ```
+    
+    The `:resources` option is usually more useful.
   
-  - `:resources` -
-    A string or collection of strings containing classpath
-    prefixes. This will serve any resources in locations starting with
-    the supplied prefix.
-
+  * `:resources` – set to a `String` containing a classpath prefix, or a collection of at least one of the same, to serve resources in locations starting with the prefix(es) given:
+    ```clojure
+    {:resources "static"}
+    {:resources #{"static" "static-supplement"}}
+    ```
 
 [1]: https://ring-clojure.github.io/ring/ring.middleware.multipart-params.html
 [2]: https://ring-clojure.github.io/ring/ring.middleware.nested-params.html
@@ -175,6 +150,8 @@ The following configuration keys are supported:
 [10]: https://ring-clojure.github.io/ring-headers/ring.middleware.x-headers.html#var-wrap-xss-protection
 [11]: https://ring-clojure.github.io/ring/ring.middleware.session.html
 [12]: https://ring-clojure.github.io/ring/ring.middleware.flash.html
+[13]: https://ring-clojure.github.io/ring/ring.middleware.session.store.html#var-SessionStore
+[14]: https://ring-clojure.github.io/ring/ring.middleware.session.memory.html#var-memory-store
 
 
 ## License


### PR DESCRIPTION
* Removes hard wrapping
* Makes headings’ case consistent
* Condenses, clarifies and harmonizes phrasing
* Adds usage examples for configuration options with non-Boolean choices
* Corrects and harmonizes punctuation
* Adds dependency instruction for Clojure Deps
* Marks up in-sentence Clojure values, HTTP values, etc.
* Replaces hyphens with asterisks in unordered lists, as they also contain dashes
* Expands link text to aid accessibility
* Adds new links
* Switches code fences to ‘interrupt’ paragraphs rather than be paragraphs