### PR TITLE
Disable the X-XSS-Protection header in defaults #35

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,9 @@ The following configuration keys are supported:
     server is on a non-standard port. See: [wrap-ssl-redirect][9].
 
   - `:xss-protection` -
-    Enable the X-XSS-Protection header that tells supporting browsers
-    to use heuristics to detect XSS attacks. See: [wrap-xss-protection][10].
+    **Deprecated.** Enable the X-XSS-Protection header. This is no
+    longer considered best practice by OWASP and should be avoided.
+    See: [wrap-xss-protection][10].
 
 - `:session` -
   A map of options for configuring session handling via the Ring

--- a/src/ring/middleware/defaults.clj
+++ b/src/ring/middleware/defaults.clj
@@ -44,7 +44,7 @@
    :session   {:flash true
                :cookie-attrs {:http-only true, :same-site :strict}}
    :security  {:anti-forgery   true
-               :xss-protection {:enable? true, :mode :block}
+               :xss-protection {:enable? false}
                :frame-options  :sameorigin
                :content-type-options :nosniff}
    :static    {:resources "public"}
@@ -78,7 +78,9 @@
         args))
 
 (defn- wrap-xss-protection [handler options]
-  (x/wrap-xss-protection handler (:enable? options true) (dissoc options :enable?)))
+  (x/wrap-xss-protection handler
+                         (:enable? options false)
+                         (-> options (dissoc :enable?) not-empty)))
 
 (defn- wrap-x-headers [handler options]
   (-> handler

--- a/test/ring/middleware/defaults_test.clj
+++ b/test/ring/middleware/defaults_test.clj
@@ -27,7 +27,7 @@
                "Set-Cookie"}))
       (is (= (get-in resp [:headers "X-Frame-Options"]) "SAMEORIGIN"))
       (is (= (get-in resp [:headers "X-Content-Type-Options"]) "nosniff"))
-      (is (= (get-in resp [:headers "X-XSS-Protection"]) "1; mode=block"))
+      (is (= (get-in resp [:headers "X-XSS-Protection"]) "0"))
       (is (= (get-in resp [:headers "Content-Type"]) "application/octet-stream"))
       (let [set-cookie (first (get-in resp [:headers "Set-Cookie"]))]
         (is (.startsWith set-cookie "ring-session="))
@@ -105,7 +105,7 @@
                "Set-Cookie"}))
       (is (= (get-in resp [:headers "X-Frame-Options"]) "SAMEORIGIN"))
       (is (= (get-in resp [:headers "X-Content-Type-Options"]) "nosniff"))
-      (is (= (get-in resp [:headers "X-XSS-Protection"]) "1; mode=block"))
+      (is (= (get-in resp [:headers "X-XSS-Protection"]) "0"))
       (is (= (get-in resp [:headers "Strict-Transport-Security"])
              "max-age=31536000; includeSubDomains"))
       (is (= (get-in resp [:headers "Content-Type"]) "application/octet-stream"))


### PR DESCRIPTION
Disable the XSS Auditor in older browsers by default.
The X-XSS-Protection header has been deprecated by modern browsers due to security issues it introduces on the client-side.

Resolves: #35