### PR TITLE
Change :absolute-redirects default to false

### DIFF
--- a/src/ring/middleware/defaults.clj
+++ b/src/ring/middleware/defaults.clj
@@ -23,7 +23,7 @@
   {:params    {:urlencoded true
                :keywordize true}
    :responses {:not-modified-responses true
-               :absolute-redirects     true
+               :absolute-redirects     false
                :content-types          true
                :default-charset        "utf-8"}})
 
@@ -49,7 +49,7 @@
                :content-type-options :nosniff}
    :static    {:resources "public"}
    :responses {:not-modified-responses true
-               :absolute-redirects     true
+               :absolute-redirects     false
                :content-types          true
                :default-charset        "utf-8"}})
 


### PR DESCRIPTION
RFC 2616 required the Location header to be an absolute URL, but this
has been superseded by RFC 7231 (section 7.1.2).